### PR TITLE
Update for paper-button-behavior-changes

### DIFF
--- a/paper-button.html
+++ b/paper-button.html
@@ -91,7 +91,7 @@ Custom property | Description | Default
       @apply(--paper-button);
     }
 
-    .focus {
+    .keyboard-focus {
       font-weight: bold;
     }
 
@@ -152,31 +152,24 @@ Custom property | Description | Default
         type: Boolean,
         reflectToAttribute: true,
         value: false,
-        observer: '_buttonStateChanged'
-      }
-
-    },
-
-    ready: function() {
-      if (!this.hasAttribute('role')) {
-        this.setAttribute('role', 'button');
+        observer: '_calculateElevation'
       }
     },
 
-    observers: [
-      `_focusedChanged(focused)`
-    ],
-
-    _buttonStateChanged: function() {
-      this._calculateElevation();
+    _calculateElevation: function() {
+      if (!this.raised) {
+        this._elevation = 0;
+      } else {
+        Polymer.PaperButtonBehaviorImpl._calculateElevation.apply(this);
+      }
     },
 
-    _computeContentClass(receivedFocusFromKeyboard) {
-      var cls = 'content ';
+    _computeContentClass: function(receivedFocusFromKeyboard) {
+      var className = 'content ';
       if (receivedFocusFromKeyboard) {
-        cls += ' focus';
+        className += ' keyboard-focus';
       }
-      return cls;
+      return className;
     }
   });
 


### PR DESCRIPTION
Raised is no longer expressed as a detail in the behavior. Since
paper-button is the only element that cares about raised, raised is
exclusively in the domain of paper-button's implementation.