### PR TITLE
Preload the font used by `.keyboard-focus`

### DIFF
--- a/paper-button.html
+++ b/paper-button.html
@@ -120,6 +120,12 @@ Custom property | Description | Default
     .content {
       padding: 0.7em 0.57em
     }
+    
+    /* preload the font used by `.keyboard-focus` */
+    ::after {
+      font-weight: bold;
+      content: "";
+    }
   </style>
 
   <template>


### PR DESCRIPTION
If a button receives focus from the keyboard, the font-face might not be ready (downloaded & decoded). This creates an undesirable visual effect; however, if the font-face is requested ahead in time, we can avoid that effect.

This seems to be the issue in https://github.com/PolymerElements/paper-button/issues/24
\cc @frankiefu 