### PR TITLE
Replace bold effect with text-shadow to avoid resize on focus.

### DIFF
--- a/paper-button.html
+++ b/paper-button.html
@@ -93,7 +93,7 @@ Custom property | Description | Default
     }
 
     .keyboard-focus {
-      font-weight: bold;
+      text-shadow: 0px 0px 1px;
     }
 
     :host([disabled]) {


### PR DESCRIPTION
This is a potential fix for bold text causing resize (issue #23).  It makes a copy of all content inside an invisible 0 height bolded div.  This ensures the button width is sufficient for when the element is focused.

Do we need to check for an attribute to disable this?  For example to deal with when the button has complex SVG with no text, it would be unneeded and potentially perform poorly.