### PR TITLE
Preserve most of the original outline

### DIFF
--- a/paper-button.html
+++ b/paper-button.html
@@ -85,7 +85,7 @@ Custom property | Description | Default
       text-align: center;
       font: inherit;
       text-transform: uppercase;
-      outline: none;
+      outline-width: 0;
       border-radius: 3px;
       -moz-user-select: none;
       -ms-user-select: none;


### PR DESCRIPTION
When `outline` is set to `none` or `0` it's impossible to revert back to the UA default. By just setting `outline-width` to `0` I can at least set it back to `3px` which gives the correct default border in Chrome. I believe Firefox uses a 2px border so it might be a little chunky but better than having to totally recreate the outline styles for different platforms.  Thanks to @atotic for the tip!