### PR TITLE
Move template back down to after the style tag.

### DIFF
--- a/paper-button.html
+++ b/paper-button.html
@@ -72,61 +72,61 @@ Custom property | Description | Default
 -->
 
 <dom-module id="paper-button">
+
+  <style>
+    :host {
+      display: inline-block;
+      position: relative;
+      box-sizing: border-box;
+      min-width: 5.14em;
+      margin: 0 0.29em;
+      background: transparent;
+      text-align: center;
+      font: inherit;
+      text-transform: uppercase;
+      outline-width: 0;
+      border-radius: 3px;
+      -moz-user-select: none;
+      -ms-user-select: none;
+      -webkit-user-select: none;
+      user-select: none;
+      cursor: pointer;
+      z-index: 0;
+
+      @apply(--paper-button);
+    }
+
+    .keyboard-focus {
+      font-weight: bold;
+    }
+
+    :host([disabled]) {
+      background: #eaeaea;
+      color: #a8a8a8;
+      cursor: auto;
+      pointer-events: none;
+
+      @apply(--paper-button-disabled);
+    }
+
+    :host([noink]) paper-ripple {
+      display: none;
+    }
+
+    paper-material {
+      border-radius: inherit;
+    }
+
+    .content > ::content * {
+      text-transform: inherit;
+    }
+
+    .content {
+      padding: 0.7em 0.57em
+    }
+  </style>
+
   <template>
-
-    <style>
-      :host {
-        display: inline-block;
-        position: relative;
-        box-sizing: border-box;
-        min-width: 5.14em;
-        margin: 0 0.29em;
-        background: transparent;
-        text-align: center;
-        font: inherit;
-        text-transform: uppercase;
-        outline-width: 0;
-        border-radius: 3px;
-        -moz-user-select: none;
-        -ms-user-select: none;
-        -webkit-user-select: none;
-        user-select: none;
-        cursor: pointer;
-        z-index: 0;
-
-        @apply(--paper-button);
-      }
-
-      .keyboard-focus {
-        font-weight: bold;
-      }
-
-      :host([disabled]) {
-        background: #eaeaea;
-        color: #a8a8a8;
-        cursor: auto;
-        pointer-events: none;
-
-        @apply(--paper-button-disabled);
-      }
-
-      :host([noink]) paper-ripple {
-        display: none;
-      }
-
-      paper-material {
-        border-radius: inherit;
-      }
-
-      .content > ::content * {
-        text-transform: inherit;
-      }
-
-      .content {
-        padding: 0.7em 0.57em
-      }
-    </style>
-
     <paper-ripple></paper-ripple>
 
     <paper-material class$="[[_computeContentClass(receivedFocusFromKeyboard)]]" elevation="[[_elevation]]" animated>


### PR DESCRIPTION
Fixes a bug in Shady DOM only that causes unexpected behavior of the
ripple.  (see demo page in Chrome):

![image](https://cloud.githubusercontent.com/assets/1316814/9453273/18ff712c-4a6e-11e5-845c-825159bfb5e1.png)

Also looks like the button text is no longer capitalized.