### PR TITLE
remove any references to ::shadow

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,33 +13,12 @@ Example:
     <paper-button raised>raised button</paper-button>
     <paper-button noink>No ripple effect</paper-button>
 ```
-You may use custom DOM in the button body to create a variety of buttons. For example, to
-create a button with an icon and some text:
 
-```html
+You may use custom DOM in the button body to create a variety of buttons. For example, to create a button with an icon and some text:
+
+```html		
     <paper-button>
       <iron-icon icon="favorite"></iron-icon>
       custom button content
     </paper-button>
 ```
-## Styling
-
-Style the button with CSS as you would a normal DOM element.
-
-```css
-    /* make #my-button green with yellow text */
-    #my-button {
-        background: green;
-        color: yellow;
-    }
-```
-By default, the ripple is the same color as the foreground at 25% opacity. You may
-customize the color using this selector:
-
-```css
-    /* make #my-button use a blue ripple instead of foreground color */
-    #my-button::shadow paper-ripple {
-      color: blue;
-    }
-```
-The opacity of the ripple is not customizable via CSS.

--- a/demo/index.html
+++ b/demo/index.html
@@ -92,12 +92,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       background: #eee;
     }
 
-    paper-button.ripple::shadow paper-ripple {
-      color: var(--paper-pink-a200);
-    }
-
-    paper-button.ripple paper-ripple {
-      color: var(--paper-pink-a200);
+    paper-button.ripple {
+      --paper-button-ink-color: var(--paper-pink-a200);
     }
 
   </style>

--- a/paper-button.html
+++ b/paper-button.html
@@ -24,10 +24,10 @@ shadow.
 
 Example:
 
-    <paper-button>flat button</paper-button>
-    <paper-button raised>raised button</paper-button>
+    <paper-button>Flat button</paper-button>
+    <paper-button raised>Raised button</paper-button>
     <paper-button noink>No ripple effect</paper-button>
-    <paper-button toggles>toggle-able button</paper-button>
+    <paper-button toggles>Toggle-able button</paper-button>
 
 A button that has `toggles` true will remain `active` after being clicked (and
 will have an `active` attribute set). For more information, see the `Polymer.IronButtonState`
@@ -45,29 +45,32 @@ create a button with an icon and some text:
 
 Style the button with CSS as you would a normal DOM element.
 
-    /* make #my-button green with yellow text */
-    #my-button {
-        background: green;
-        color: yellow;
+    paper-button.fancy {
+      background: green;
+      color: yellow;
+    }
+
+    paper-button.fancy:hover {
+      background: lime;
+    }
+
+    paper-button[disabled],
+    paper-button[toggles][active] {
+      background: red;
     }
 
 By default, the ripple is the same color as the foreground at 25% opacity. You may
-customize the color using this selector:
-
-    /* make #my-button use a blue ripple instead of foreground color */
-    #my-button::shadow paper-ripple {
-      color: blue;
-    }
-
-The opacity of the ripple is not customizable via CSS.
+customize the color using the `--paper-button-ink-color` custom property.
 
 The following custom properties and mixins are also available for styling:
 
 Custom property | Description | Default
 ----------------|-------------|----------
-`--paper-button-flat-focus-color` | Background color of a focused flat button | `--paper-grey-200`
+`--paper-button-ink-color` | Background color of the ripple | `Based on the button's color`
 `--paper-button` | Mixin applied to the button | `{}`
-`--paper-button-disabled` | Mixin applied to the disabled button | `{}`
+`--paper-button-disabled` | Mixin applied to the disabled button. Note that you can also use the `paper-button[disabled]` selector | `{}`
+`--paper-button-flat-keyboard-focus` | Mixin applied to a flat button after it's been focused using the keyboard | `{}`
+`--paper-button-raised-keyboard-focus` | Mixin applied to a raised button after it's been focused using the keyboard | `{}`
 
 @demo demo/index.html
 -->
@@ -99,8 +102,14 @@ Custom property | Description | Default
         @apply(--paper-button);
       }
 
-      .keyboard-focus {
+      :host([raised]) .keyboard-focus {
         font-weight: bold;
+        @apply(paper-button-raised-keyboard-focus);
+      }
+
+      :host(:not([raised])) .keyboard-focus {
+        font-weight: bold;
+        @apply(paper-button-flat-keyboard-focus);
       }
 
       :host([disabled]) {
@@ -114,6 +123,10 @@ Custom property | Description | Default
 
       :host([noink]) paper-ripple {
         display: none;
+      }
+
+      paper-ripple {
+        color: var(--paper-button-ink-color);
       }
 
       paper-material {

--- a/test/paper-button.html
+++ b/test/paper-button.html
@@ -54,10 +54,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }, 1);
       });
 
-      test('has aria role "button"', function() {
-        expect(button.getAttribute('role')).to.be.eql('button');
-      });
-
       test('can be disabled imperatively', function() {
         button.disabled = true;
         expect(button.getAttribute('aria-disabled')).to.be.eql('true');
@@ -78,6 +74,21 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         MockInteractions.pressEnter(button);
       });
     });
+
+    suite('<paper-button>', function() {
+      var button;
+
+      setup(function() {
+        button = fixture('TrivialButton');
+      });
+
+      test('has aria role "button"', function() {
+        expect(button.getAttribute('role')).to.be.eql('button');
+      });
+      
+      a11ySuite('TrivialButton');
+    });
+
   </script>
 </body>
 </html>


### PR DESCRIPTION
Also added:
- bonus custom properties for the ripple color
- custom properties for the `flat` vs `raised` keyboard-focus styles
- there was an unused `--paper-button-flat-focus-color` property which i nuked (and probably was meant to be one of the two above)

:cactus: 