### PR TITLE
Apply .keyboard-focus style to <content> node

### DIFF
--- a/paper-button.html
+++ b/paper-button.html
@@ -102,12 +102,12 @@ Custom property | Description | Default
         @apply(--paper-button);
       }
 
-      :host([raised]) .keyboard-focus {
+      :host([raised]) #content-wrapper.keyboard-focus {
         font-weight: bold;
         @apply(--paper-button-raised-keyboard-focus);
       }
 
-      :host(:not([raised])) .keyboard-focus {
+      :host(:not([raised])) #content-wrapper.keyboard-focus {
         font-weight: bold;
         @apply(--paper-button-flat-keyboard-focus);
       }
@@ -141,9 +141,11 @@ Custom property | Description | Default
 
     <paper-ripple></paper-ripple>
 
-    <paper-material class$="[[_computeContentClass(receivedFocusFromKeyboard)]]" elevation="[[_elevation]]" animated></paper-material>
+    <paper-material  elevation="[[_elevation]]" animated></paper-material>
 
-    <content></content>
+    <div id="content-wrapper" class$="[[_computeContentClass(receivedFocusFromKeyboard)]]">
+      <content></content>
+    </div>
 
   </template>
 </dom-module>

--- a/paper-button.html
+++ b/paper-button.html
@@ -51,7 +51,7 @@ Style the button with CSS as you would a normal DOM element.
     }
 
     paper-button.fancy:hover {
-      background: lime;
+      background: lime;c
     }
 
     paper-button[disabled],
@@ -102,12 +102,12 @@ Custom property | Description | Default
         @apply(--paper-button);
       }
 
-      :host([raised]) #content-wrapper.keyboard-focus {
+      :host([raised]) .keyboard-focus {
         font-weight: bold;
         @apply(--paper-button-raised-keyboard-focus);
       }
 
-      :host(:not([raised])) #content-wrapper.keyboard-focus {
+      :host(:not([raised])) .keyboard-focus {
         font-weight: bold;
         @apply(--paper-button-flat-keyboard-focus);
       }
@@ -143,7 +143,7 @@ Custom property | Description | Default
 
     <paper-material  elevation="[[_elevation]]" animated></paper-material>
 
-    <div id="content-wrapper" class$="[[_computeContentClass(receivedFocusFromKeyboard)]]">
+    <div class$="[[_computeContentClass(receivedFocusFromKeyboard)]]">
       <content></content>
     </div>
 

--- a/paper-button.html
+++ b/paper-button.html
@@ -51,7 +51,7 @@ Style the button with CSS as you would a normal DOM element.
     }
 
     paper-button.fancy:hover {
-      background: lime;c
+      background: lime;
     }
 
     paper-button[disabled],


### PR DESCRIPTION
Fixes issue #55.

Alternatively we could move \<content> back inside the \<paper-material> -- WDYT?