### PR TITLE
update jsdoc object notation

### DIFF
--- a/paper-button.html
+++ b/paper-button.html
@@ -166,8 +166,7 @@ Custom property | Description | Default
     the ripple animation finishes to perform some action.
 
     @event transitionend
-    @param {Object} detail
-    @param {Object} detail.node The animated node
+    @param {{node: Object}} detail Contains the animated node.
     */
   });
 </script>


### PR DESCRIPTION
This notation is needed since some jsdoc compilers will not accept the `.` in the param name.