### PR TITLE
set elevation like the read-only property it is

### DIFF
--- a/paper-button.html
+++ b/paper-button.html
@@ -154,7 +154,7 @@ Custom property | Description | Default
 
     _calculateElevation: function() {
       if (!this.raised) {
-        this.elevation = 0;
+        this._setElevation(0);
       } else {
         Polymer.PaperButtonBehaviorImpl._calculateElevation.apply(this);
       }

--- a/test/paper-button.html
+++ b/test/paper-button.html
@@ -19,7 +19,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script src="../../iron-test-helpers/mock-interactions.js"></script>
 
   <link rel="import" href="../paper-button.html">
-  
+
 </head>
 <body>
 
@@ -49,6 +49,22 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           } catch (e) {
             done(e);
           }
+        }, 1);
+      });
+
+      test('can be unraised after being raised imperatively', function(done) {
+        button.raised = true;
+        expect(button.hasAttribute('raised')).to.be.eql(true);
+
+        Polymer.Base.async(function() {
+          expect(button.elevation).to.be.eql(1);
+
+          button.raised = false;
+          expect(button.hasAttribute('raised')).to.be.eql(false);
+          Polymer.Base.async(function() {
+            expect(button.elevation).to.be.eql(0);
+            done();
+          }, 1);
         }, 1);
       });
 


### PR DESCRIPTION
Fixes https://github.com/PolymerElements/paper-button/issues/79.

All the king's horses and all the king's men won't change the fact that `elevation` is read-only (from `PaperButtonBehavior`) and it can't be simply assigned to.