### PR TITLE
fix jumping around when bold

### DIFF
--- a/paper-button.html
+++ b/paper-button.html
@@ -97,17 +97,18 @@ Custom property | Description | Default
         cursor: pointer;
         z-index: 0;
         padding: 0.7em 0.57em;
-
         @apply(--paper-button);
       }
 
       :host([raised].keyboard-focus) {
         font-weight: bold;
+        letter-spacing: -0.1px;
         @apply(--paper-button-raised-keyboard-focus);
       }
 
       :host(:not([raised]).keyboard-focus) {
         font-weight: bold;
+        letter-spacing: -0.1px;
         @apply(--paper-button-flat-keyboard-focus);
       }
 


### PR DESCRIPTION
I don't think https://github.com/PolymerElements/paper-button/issues/23 has been fixed (I see the buttons jumping around a bit in the demo), so here's a little hack that might make it better. What do you think?

(I think the issue was auto closed because we closed the PR, but I don't remember every having a real fix for it...)