### PR TITLE
Compiler doesn't like @param for event params

### DIFF
--- a/paper-button.html
+++ b/paper-button.html
@@ -166,7 +166,7 @@ Custom property | Description | Default
     the ripple animation finishes to perform some action.
 
     @event transitionend
-    @param {{node: Object}} detail Contains the animated node.
+    Event param: {{node: Object}} detail Contains the animated node.
     */
   });
 </script>


### PR DESCRIPTION
In some configurations it seems like it will throw an error because it can't find the corresponding function.