### PR TITLE
Remove unneeded CSS style

### DIFF
--- a/paper-button.html
+++ b/paper-button.html
@@ -130,10 +130,6 @@ Custom property | Description | Default
       paper-ripple {
         color: var(--paper-button-ink-color);
       }
-
-      :host > ::content * {
-        text-transform: inherit;
-      }
     </style>
 
     <content></content>


### PR DESCRIPTION
Light DOM children will still inherit `text-transform: uppercase` from paper-button :host styles.

Fixes #99.