### PR TITLE
adjust :host specificity

### DIFF
--- a/paper-button.html
+++ b/paper-button.html
@@ -84,7 +84,8 @@ Custom property | Description | Default
 <dom-module id="paper-button">
   <template strip-whitespace>
     <style include="paper-material">
-      :host {
+      /* Need to specify the same specificity as the styles imported from paper-material. */
+      :host, :host(.paper-material) {
         @apply --layout-inline;
         @apply --layout-center-center;
         position: relative;


### PR DESCRIPTION
Or else the `paper-material` styles win, and the 1.0 button relies on them not.