### PR TITLE
Click parent anchors on enter and space

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -122,7 +122,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <demo-snippet class="centered-demo">
       <template>
         <a href="https://www.polymer-project.org/" tabindex="-1">
-          <paper-button raised>Polymer Project</paper-button>
+          <paper-button raised link>Polymer Project</paper-button>
         </a>
         <style>
           a paper-button,

--- a/paper-button.html
+++ b/paper-button.html
@@ -162,6 +162,27 @@ Custom property | Description | Default
           reflectToAttribute: true,
           value: false,
           observer: '_calculateElevation'
+        },
+
+        /**
+         * If true, the button will forward keyboard clicks (enter/space) to
+         * the parent anchor element found if exists
+         */
+        link: {
+          type: Boolean,
+          value: false,
+          reflectToAttribute: true
+        }
+      },
+
+      listeners: {
+        tap: '_onTap'
+      },
+
+      _onTap: function (ev) {
+        if (this.link && this.parentNode && this.parentNode.tagName === 'A') {
+          // Click the anchor if exists.
+          this.parentNode.click();
         }
       },
 


### PR DESCRIPTION
Not sure of the proper protocol or if this is a sufficient PR. Hopefully this helps though.

Changes:

- Add `link` attribute to `paper-button` to stay consistent with `paper-tabs`.
- Add handler for `tap` to trigger the parent anchor element if it exists.

Fixes #147.