### PR TITLE
Button touch area's height enlarged in order to fulfill Material Desi…

### DIFF
--- a/paper-button.html
+++ b/paper-button.html
@@ -110,6 +110,15 @@ Custom property | Description | Default
         @apply(--paper-button);
       }
 
+      :host::after {
+        content: '';
+        position: absolute;
+        top: -0.429em;
+        bottom: -0.429em;
+        left: 0;
+        right: 0;
+      }
+
       :host([hidden]) {
         display: none !important;
       }


### PR DESCRIPTION
…gn guidlines.

The current implementation does not follow the Material Design Accessibility Guidelines about Touch Area's size:
https://material.io/guidelines/components/buttons.html#buttons-style
![md_buttons_accessibility](https://cloud.githubusercontent.com/assets/7813326/24552119/8f9e81ea-1625-11e7-911e-fcf1f4b58238.png)
