### PR TITLE
Make disabled flat button consistent with enabled.

### DIFF
--- a/paper-button.html
+++ b/paper-button.html
@@ -146,7 +146,6 @@ Custom property | Description | Default
       }
 
       :host([disabled]) {
-        background: #eaeaea;
         color: #a8a8a8;
         cursor: auto;
         pointer-events: none;
@@ -154,6 +153,10 @@ Custom property | Description | Default
         @apply --paper-button-disabled;
       }
 
+      :host([disabled][raised]) {
+        background: #eaeaea;
+      }
+        
       :host([animated]) {
         @apply --shadow-transition;
       }


### PR DESCRIPTION
While enabled flat (not raised) button has no background, disabled version does which is inconsistent and looks bad. Change adds background for raised disabled buttons only.