### PR TITLE
Fix previous change in paper-button.html

### DIFF
--- a/paper-button.html
+++ b/paper-button.html
@@ -146,6 +146,7 @@ Custom property | Description | Default
       }
 
       :host([disabled]) {
+        background: none;
         color: #a8a8a8;
         cursor: auto;
         pointer-events: none;


### PR DESCRIPTION
Fix of https://github.com/PolymerElements/paper-button/pull/180
Apparently some flat button backgrounds are made raised+not-disabled (blue) when they are actually get disabled. Spotted by scuba test (at report no. 55e88107-6691-406f-bb5e-7a332d816786)